### PR TITLE
Clarify Python code linting and formatting instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Linting
 
-Lint all Python code with [ruff](https://docs.astral.sh/ruff/).
+Lint and format all Python code with [ruff](https://docs.astral.sh/ruff/).
 
 ## Import Style
 


### PR DESCRIPTION
Updated instructions to specify both linting and formatting for Python code.